### PR TITLE
added property ExcludedFromBuild to shader files in CMakeLists.txt

### DIFF
--- a/Orbitersdk/D3D9Client/CMakeLists.txt
+++ b/Orbitersdk/D3D9Client/CMakeLists.txt
@@ -139,6 +139,10 @@ set(ShaderFiles
 
 source_group(Shaders FILES ${ShaderFiles})
 
+set_property(SOURCE ${ShaderFiles}
+    PROPERTY VS_SETTINGS "ExcludedFromBuild=true"
+)
+
 add_library(D3D9Client MODULE
 	${SourceFiles}
 	${IncludeFiles}


### PR DESCRIPTION
This excludes the shader files from build without the need for editing the VS project file manually.