### PR TITLE
D3D9Client now builds for x64 and x86 platforms.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,23 +2,33 @@
 
 cmake_minimum_required(VERSION 3.10)
 
+# set the project name and version
+project(D3D9Client VERSION 31.0)
+
 # Additional compiler flags
 set(Flags "/MP")
+
+# Check build platform
+if(CMAKE_SIZEOF_VOID_P EQUAL 8) # 64-bit build?
+	set(BUILD64 1)
+	set(ARCH "x64")
+else()
+	set(BUILD64 0)
+	set(ARCH "x86")
+endif()
 
 # Location of DirectX SDK
 # set(DXSDK_DIR "C:/Program Files (x86)/Microsoft DirectX SDK (June 2010)")
 
 if (NOT "$ENV{DXSDK_DIR}" STREQUAL "")
-    set(DXSDK_DIR "$ENV{DXSDK_DIR}")
+	file(TO_CMAKE_PATH "$ENV{DXSDK_DIR}" DXSDK_DIR)
 else()
-    set(DXSDK_DIR "C:/Program Files (x86)/Microsoft DirectX SDK (June 2010)/")
+    set(DXSDK_DIR "C:/Program Files (x86)/Microsoft DirectX SDK (June 2010)")
 endif()
+set(DXSDK_LIB_DIR ${DXSDK_DIR}/lib/${ARCH})
 
 set(ORBITER_SOURCE_SDK_INCLUDE_DIR ${CMAKE_BINARY_DIR}/Orbitersdk/include)
 set(ORBITER_SOURCE_SDK_LIB_DIR ${CMAKE_BINARY_DIR}/Orbitersdk/lib)
-
-# set the project name and version
-project(D3D9Client VERSION 31.0)
 
 add_subdirectory(Orbitersdk/D3D9Client)
 add_subdirectory(Orbitersdk/samples/DX9ExtMFD)

--- a/Orbitersdk/D3D9Client/CMakeLists.txt
+++ b/Orbitersdk/D3D9Client/CMakeLists.txt
@@ -152,12 +152,12 @@ add_library(D3D9Client MODULE
 
 target_include_directories(D3D9Client PUBLIC
 	${ORBITER_SOURCE_SDK_INCLUDE_DIR}
-	${DXSDK_DIR}Include
+	${DXSDK_DIR}/Include
 )
 
 target_link_directories(D3D9Client PUBLIC
 	${ORBITER_SOURCE_SDK_LIB_DIR}
-	${DXSDK_DIR}Lib/x64
+	${DXSDK_LIB_DIR}
 )
 
 target_link_libraries(D3D9Client

--- a/Orbitersdk/samples/DX9ExtMFD/MFDWindow.cpp
+++ b/Orbitersdk/samples/DX9ExtMFD/MFDWindow.cpp
@@ -351,7 +351,7 @@ LRESULT CALLBACK MFD_WndProc (HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 }
 
 
-INT_PTR FAR PASCAL MFD_BtnProc (HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+LRESULT FAR PASCAL MFD_BtnProc (HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
 	switch (uMsg) {
 	case WM_PAINT: {

--- a/Orbitersdk/samples/GenericCamera/Shell.cpp
+++ b/Orbitersdk/samples/GenericCamera/Shell.cpp
@@ -102,7 +102,7 @@ void ShellMFD::ExitModule(HINSTANCE hDLL)
 
 // ============================================================================================================
 //
-LONG_PTR ShellMFD::MsgProc(UINT msg, UINT mfd, WPARAM wparam, LPARAM lparam)
+OAPI_MSGTYPE ShellMFD::MsgProc(UINT msg, UINT mfd, WPARAM wparam, LPARAM lparam)
 {
 
     if (msg==OAPI_MSG_MFD_OPENED && MFDList) {	

--- a/Orbitersdk/samples/GenericCamera/Shell.h
+++ b/Orbitersdk/samples/GenericCamera/Shell.h
@@ -89,7 +89,7 @@ public:
 	//
 	static void	InitModule(HINSTANCE hDLL);
 	static void ExitModule(HINSTANCE hDLL);
-	static LONG_PTR MsgProc(UINT msg, UINT mfd, WPARAM wparam, LPARAM lparam);
+	static OAPI_MSGTYPE MsgProc(UINT msg, UINT mfd, WPARAM wparam, LPARAM lparam);
 
 private:
 	UINT id;			// Logical MFD identifier MFD_LEFT, MFD_RIGHT...


### PR DESCRIPTION
This should now build when configured for "x64" or "Win32".

The "OAPI_MSGTYPE" type is defined by Orbiter to ensure backward compatibility for existing 32-bit addons which rely on "int" return type for message callbacks, This type can be dropped again once we decide to break backward compatibility.